### PR TITLE
Fix ethan_workbench iOS deploys hanging on Watch+SPM companion detection

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		AA3E3C162F1E62DD0060CEF4 /* WorkoutsWatch Watch App */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				AA3E3C172F1E62DE0060CEF4 /* Exceptions for "WorkoutsWatch Watch App" folder in "WorkoutsWatch Watch App" target */,
 			);
 			explicitFileTypes = {
 			};
@@ -99,6 +100,16 @@
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		AA3E3C172F1E62DE0060CEF4 /* Exceptions for "WorkoutsWatch Watch App" folder in "WorkoutsWatch Watch App" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = AA3E3C142F1E62DD0060CEF4 /* WorkoutsWatch Watch App */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
@@ -752,6 +763,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "WorkoutsWatch Watch App/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = WorkoutsWatch;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Workouts reads heart rate during workouts to track your training intensity.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Workouts saves workout data to track your training history.";
@@ -803,6 +815,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "WorkoutsWatch Watch App/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = WorkoutsWatch;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Workouts reads heart rate during workouts to track your training intensity.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Workouts saves workout data to track your training history.";
@@ -851,6 +864,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "WorkoutsWatch Watch App/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = WorkoutsWatch;
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "Workouts reads heart rate during workouts to track your training intensity.";
 				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Workouts saves workout data to track your training history.";

--- a/ios/WorkoutsWatch Watch App/Info.plist
+++ b/ios/WorkoutsWatch Watch App/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>me.ethanp.workouts</string>
+</dict>
+</plist>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
iOS deploys via ethan_workbench started failing/hanging after the Aug 8 CocoaPods → SwiftPM migration.

Workouts embeds a Watch companion that only declared `WKCompanionAppBundleIdentifier` via `INFOPLIST_KEY_*` build settings (no literal `Info.plist` key). Flutter’s watch-companion detection then falls through to probing every SwiftPM package scheme with `xcodebuild` ([flutter#186004](https://github.com/flutter/flutter/issues/186004)), which can stall `flutter build ios` for minutes and break workbench deploys.

## Fix
- Add `ios/WorkoutsWatch Watch App/Info.plist` with literal `WKCompanionAppBundleIdentifier = me.ethanp.workouts` so Flutter takes the cheap detection path
- Point Watch Debug/Release/Profile at that plist via `INFOPLIST_FILE`
- Exclude `Info.plist` from the synchronized folder’s resource membership so it isn’t copied twice

## Verify
On the Mac (workbench deploy path):

```bash
cd workouts
ruby ../ethan_workbench/deploy.rb ios --force
```

Or at least confirm `flutter build ios --release --no-tree-shake-icons` no longer stalls before “Running Xcode build…”.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53b77280-14d0-4d9e-b1a4-be69b846bd32?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53b77280-14d0-4d9e-b1a4-be69b846bd32&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

